### PR TITLE
Check for the env var mentioned by playdate docs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,7 +65,7 @@ jobs:
           # - ubuntu-latest
           # - windows-latest
         sdk:
-          - latest
+          - 1.9.2
 
     steps:
       - uses: actions/checkout@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,7 +162,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "crank"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "Inflector",
  "anyhow",

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,0 @@
-nightly

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,8 +68,15 @@ fn playdate_sdk_path() -> Result<PathBuf, Error> {
 }
 
 fn playdate_sdk_path_default() -> Result<PathBuf, Error> {
-    let home_dir = dirs::home_dir().ok_or(anyhow!("Can't find home dir"))?;
-    Ok(home_dir.join(SDK_DIR).join("PlaydateSDK"))
+    let sdk_location = match env::var("PLAYDATE_SDK_PATH") {
+        Ok(path) => PathBuf::from(path),
+        Err(_) => {
+            // couldn't find the expected env variable, try defaulting to their home directory
+            let home_dir = dirs::home_dir().ok_or(anyhow!("Can't find home dir"))?;
+            home_dir.join(SDK_DIR).join("PlaydateSDK")
+        }
+    };
+    Ok(sdk_location)
 }
 
 fn playdate_c_api_path() -> Result<PathBuf, Error> {


### PR DESCRIPTION
The [official docs](https://sdk.play.date/1.9.3/Inside%20Playdate.html#_set_playdate_sdk_path_environment_variable) say to set `PLAYDATE_SDK_PATH` so it should be a pretty reliable way to find the SDK.

I've also got [another branch](https://github.com/skeet70/crank/tree/linux-build-custom-target) off this one that makes everything work for my specific setup, but I haven't generalized it (my `target` is in a `/tmp/` ramdisk). The one piece that may be generally useful there is [this change](https://github.com/skeet70/crank/blob/linux-build-custom-target/src/main.rs#L461) which makes the run command use the SDK path too (`open` doesn't exist on my distro).

With the changes in both those branches done, I can confirm everything in `hello_world` (and `crankstart-klondike`) works on Arch Linux w/ kernel `5.15.33-1-lts`.