### PR TITLE
CI: add release workflow

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,97 @@
+# CI Workflows
+
+## Release pipelines
+
+There is two ways to release:
+1. Just bump version in the Cargo.toml, then commit to main branch. See [more about this pipeline][release-by-crate-version].
+2. Push new tag to main branch. See [more about this pipeline][release-by-git-tag].
+
+
+### By Crate Version
+
+Can be trigged by:
+__Version of the crate don't equal to the latest git-tag for this commit.__
+
+Branches where can be triggered:
+- main
+- master
+- `release-v?[0-9]+\.[0-9]+.*`
+
+_Note: Everywhare where mention the "main" branch in this document, that means this list of branches._
+
+
+Steps will happen:
+1. Determine the version of the crate
+2. Determin latest git tag for _this_ commit
+3. Compare. Breake if equal or if cannot push tag because it already exists
+4. Push new tag to _this_ commit, named as the version (see [version conversion][])
+5. Execute [main release workflow][release-by-git-tag].
+
+
+#### __Usage__
+
+__PR Way:__
+1. checkout the main branch
+1. create new branch for future PR
+1. bump version in the Cargo.toml
+1. commit, push, PR
+1. wait review & merge <br/>
+When you PR merged to main branch, pipeline will check the version and try to create tag and release.
+1. go to [releases][]
+1. edit description of the new created by pipeline release (you can _save_ without publication)
+2. wait all builds
+3. publish the release.
+
+_Do not publish before all builds are done because it can break the pipeline. After publication, url for upload artifacts (builds) can be (will) changed, so later builds can't be attached to this release page._
+
+__Hardcore Way:__
+
+Same as above but just commit to master/main without PR. So see above and skip steps 2 and 5.
+
+
+#### Configuration
+
+There used [GH-action][tag-crate-version] to do all work.
+
+Important options for future twicks:
+- `tag-to-version`
+- `version-to-tag`
+
+
+[version conversion]: #configuration
+[releases]: https://github.com/pd-rs/crank/releases
+[tag-crate-version]: https://github.com/pontem-network/tag-crate-version#parameters
+
+
+
+### By Git Tag
+
+Can be trigged by:
+__New tag pushed to main branch.__
+
+Branches where can be triggered:
+- main
+- master
+- `release-v?[0-9]+\.[0-9]+.*`
+
+Tags what can be trigger the pipeline:
+- `v?[0-9]+.[0-9]+\.*`
+
+Steps will happen:
+1. Workflow starts automatically, thanks to GH.
+
+
+__Usage__
+
+Same as [first workflow above][release-by-crate-version] but instead of edit file you should push the tag to main branch, without any forks and PRs.
+
+__PR Way:__
+1. checkout the main branch
+2. push new tag
+3. go to [releases][]
+4. [same steps about release editing and publication.](#usage)
+
+
+
+[release-by-git-tag]: #by-git-tag
+[release-by-crate-version]: #by-crate-version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,142 @@
+name: Release
+on:
+  push:
+    tags:
+      - v?[0-9]+.[0-9]+**
+  workflow_call:
+    inputs:
+      tag:
+        description: Target tag
+        required: true
+        type: string
+
+jobs:
+  release:
+    name: page
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: extract the version tag
+        id: version
+        run: |
+          if [ -z "${{ inputs.tag }}" ]; then
+              echo ::set-output name=value::$(echo $GITHUB_REF | cut -d / -f 3)
+          else
+              echo ::set-output name=value::${{ inputs.tag }}
+          fi
+
+      # checkout needed for changelog only
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: ${{ steps.version.outputs.value }}
+
+      - id: changelog
+        name: Generate Changelog
+        continue-on-error: true
+        run: |
+          RESULT_FILE=generated-changelog.md
+
+          echo "
+          ## TODO: EDIT ME BEFORE PUBLISH
+
+          [link-main]: ${{ github.event.repository.html_url }}/actions?query=workflow%3A%22Release%22
+          [badge-main]: ${{ github.event.repository.html_url }}/workflows/Release/badge.svg?event=workflow_call (main workflow)
+
+          __Please wait build completions for:__
+          - [![Build Release Tools][badge-main]][link-main]
+
+          Generate __changelog__:
+          - Just edit this
+          - Press the button "+ Auto-generate release notes"
+
+          - - -
+
+          ## Changelog
+
+          ...
+
+          <!-- Built with ♥️. -->
+          " > $RESULT_FILE
+
+          echo ::set-output name=file::"$RESULT_FILE"
+
+      - id: release
+        name: create release ${{ steps.version.outputs.value }}
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          draft: true
+          prerelease: true
+          tag_name: ${{ steps.version.outputs.value }}
+          release_name: ${{ steps.version.outputs.value }}
+          body_path: ${{ steps.changelog.outputs.file }}
+
+    outputs:
+      tag: ${{ steps.version.outputs.value }}
+      upload_url: ${{ steps.release.outputs.upload_url }}
+      html_url: ${{ steps.release.outputs.html_url }}
+
+  build:
+    needs: release
+    name: ${{ matrix.os.name }}
+    runs-on: ${{ matrix.os.value }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - name: macos
+            value: macos-latest
+          - name: ubuntu
+            value: ubuntu-latest
+          - name: windows
+            value: windows-latest
+    defaults:
+      run:
+        shell: bash
+    env:
+      CARGO_INCREMENTAL: 0
+      RUSTUP_MAX_RETRIES: 10
+      CARGO_NET_RETRY: 10
+
+    steps:
+      - name: metadata
+        id: build-info
+        run: |
+          echo "${{ needs.release.outputs.tag }}"
+          echo "${{ needs.release.outputs.upload_url }}"
+
+          uname -a > build-info.txt
+          rustc -V >> build-info.txt
+          echo "::set-output name=arch::$(uname -m)"
+
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - name: rust cache
+        uses: Swatinem/rust-cache@v1
+
+      - name: build
+        run: cargo build --release
+
+      - name: upload
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.release.outputs.upload_url }}
+          asset_path: "target/release/crank${{ matrix.os.name == 'windows' && '.exe' || '' }}"
+          asset_name: crank-${{ matrix.os.name }}-${{ steps.build-info.outputs.arch }}
+          asset_content_type: application/octet-stream

--- a/.github/workflows/tagger.yml
+++ b/.github/workflows/tagger.yml
@@ -1,0 +1,50 @@
+# This workflow checking and comparing crate version by cargo-metadata with latest tag by git,
+# then trying to push new tag, the trigger release workflow.
+name: Tag Version
+on:
+  push:
+    branches:
+      - main
+      - master
+      - release-v?[0-9]+.[0-9]+**
+
+jobs:
+  push-tag:
+    name: Tag crate version
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: install rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - id: new_tag
+        name: try create tag
+        uses: pontem-network/tag-crate-version@v0.1.0
+        with:
+          # crate: crank # optional, auto-determable
+          version-to-tag: "$1"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pwd: ${{github.workspace}}
+
+    outputs:
+      crate: ${{ steps.new_tag.outputs.crate }}
+      version: ${{ steps.new_tag.outputs.current }}
+      tag: ${{ steps.new_tag.outputs.tag }}
+      prev-tag: ${{ steps.new_tag.outputs.previous }}
+      success: ${{ steps.new_tag.outputs.success }}
+
+  release:
+    needs: push-tag
+    if: needs.push-tag.outputs.success
+    uses: pd-rs/crank/.github/workflows/release.yml@main
+    # ^should be:
+    # uses: ${{ github.event.repository.full_name }}/.github/workflows/release.yml@${{ github.ref }} or ${{ needs.push-tag.outputs.tag }}
+    # but github don't want implement two-pass- templator for it, yet :(
+    with:
+      tag: ${{ needs.push-tag.outputs.tag }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,7 +68,9 @@ jobs:
           - latest
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
+
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -78,7 +80,10 @@ jobs:
           profile: minimal
           override: true
 
-      - name: Install
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v1
+
+      - name: Install Crank
         run: cargo install --path . --force
 
       - name: Checkout Crankstart
@@ -94,7 +99,7 @@ jobs:
         with:
           version: ${{ matrix.sdk }}
 
-      - name: info
+      - name: Info
         run: |
           which pdc
           pdc --version

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,32 +87,12 @@ jobs:
           repository: rtsuk/crankstart
           path: crankstart
 
-      - name: install SDK (macos)
-        if: ${{ matrix.os == 'macos-latest' }}
-        run: |
-          curl -L --silent --show-error --fail "https://download.panic.com/playdate_sdk/PlaydateSDK-${{ matrix.sdk }}.zip" -o sdk.zip
-          unzip sdk.zip
-          sudo installer -store -pkg "PlaydateSDK.pkg" -target /
-          cat ~/.Playdate/config
-
-      - name: install SDK (linux)
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: |
-          curl -L --silent --show-error --fail "https://download.panic.com/playdate_sdk/Linux/PlaydateSDK-${{ matrix.sdk }}.tar.gz" -o sdk.tar.gz
-          mkdir sdk
-          tar -zxf sdk.tar.gz -C sdk
-          cd sdk/*/
-          sudo ./setup.sh || true
-          echo "PLAYDATE_SDK_PATH=$PWD" >> $GITHUB_ENV
-          echo "$PWD/bin" >> $GITHUB_PATH
-          # echo "$PLAYDATE_SDK_PATH" > "$HOME/.Playdate/config"
-
-      - name: install SDK (windows)
-        if: ${{ matrix.os == 'windows-latest' }}
-        run: |
-          curl -L --silent --show-error --fail "https://download.panic.com/playdate_sdk/Windows/PlaydateSDK-${{ matrix.sdk }}.exe" -o sdk.exe
-          # TODO: install sdk.exe
-          ./sdk.exe --quiet
+      - name: Install Playdate SDK
+        id: sdk
+        # then use ${{ steps.sdk.outputs.root/version }}
+        uses: pd-rs/get-playdate-sdk@main
+        with:
+          version: ${{ matrix.sdk }}
 
       - name: info
         run: |


### PR DESCRIPTION
- Improved tests-workflow: use gh-action to get the SDK;
- Added readme that describes new pipelines and usage.

Feel free to suggest changes and fix my "broken English" for better wording.

<img width="960" alt="Screenshot 2022-04-21 at 19 31 24" src="https://user-images.githubusercontent.com/888526/164495721-298269ff-8e2b-4879-ae65-cc9312950155.png">

