### PR TITLE
Add Linux support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,8 +61,8 @@ jobs:
       matrix:
         os:
           - macos-latest
-          # TODO: enable linux & windows and fix the crank
-          # - ubuntu-latest
+          - ubuntu-latest
+          # TODO: enable windows and fix the crank
           # - windows-latest
         sdk:
           - latest


### PR DESCRIPTION
This PR adds better Linux support to Crank with the following minor changes:

* Assume `arm-none-eabi-gcc` and `arm-none-eabi-objcopy` are in PATH env var instead of using static paths on Linux
* Add support for specifying `PLAYDATE_SERIAL_DEVICE` and `PLAYDATE_MOUNT_POINT` with reasonable defaults on Linux (note: untested since I've not received my Playdate yet)
* Use `eject` command to eject the Playdate on non-macOS (note: untested since I've not received my Playdate yet)
* Assume `PlaydateSimulator` is in PATH on non-macOS instead of using the macOS-specific `open -a`
* Reveal pdx via `xdg-open` on Linux (that tool will use whatever the default file manager is, but does not natively support selecting a particular file)

The CI should pass once pd-rs/get-playdate-sdk#5 is merged or the apt command is put into this workflow (depending on which is decided there)

Let me know if anything is problematic or otherwise unclear. Thank you for making these tools and libraries!