### PR TITLE
Fix intermittent (but frequent) failure to copy files

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -468,9 +468,14 @@ impl Build {
             thread::sleep(duration);
         }
 
-        thread::sleep(duration * 5);
-
         let games_dir = data_path.join("Games");
+
+        // This prevents issues that occur when the PLAYDATE volume is mounted
+        // but not all of the inner folders are available yet.
+        while !games_dir.exists() {
+            thread::sleep(duration);
+        }
+
         let game_device_dir = format!("{}.pdx", example_title);
         let games_target_dir = games_dir.join(&game_device_dir);
         fs::create_dir(&games_target_dir).ok();


### PR DESCRIPTION
I just got my new playdate and was having a tough time getting `crank` to successfully copy files to the playdate.

I tracked it down to a timing issue. It seems like the PLAYDATE volume would be mounted but not fully available. This fix changes the code to wait until the "Games" folder can be read.

I also removed another arbitrary sleep that I presume was there to prevent something similar? The new check should more reliably handle whatever that other sleep was for.

*Edit:* I'm deploying from a Mac