### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,4 +46,4 @@ The command `build` is a bit of a misnomer, as it both builds, creates a .pdx di
 
 In order to include assets like images, crank optionally reads a Crank.toml file with lists of files to include in the .pdx directory. See the wrapper repository for an example.
 
-Crank is only regularly tested on Mac, but has worked on Windows in the past.
+Crank is only regularly tested on Mac, but has worked on Windows and Linux in the past.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Rust toolchains __nightly__ needed for [build-std][] feature, installed with `ru
 
 [build-std]: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#build-std
 
+All of the requirements listed in [Inside Playdate with C](https://sdk.play.date/inside-playdate-with-c#_prerequisites).
+
 ## Installation
 
 Since crank is not yet on crates.io, one needs to download it with git and install it with cargo.

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ Crank is a wrapper for cargo when creating games for the [Playdate handheld gami
 
 This software is not sponsored or supported by Panic.
 
-Note: Development is on hold until the SDK is made available to the public.
-
 ## Requirements
 
 The Playdate SDK installed in `$HOME/Developer/PlaydateSDK`.


### PR DESCRIPTION
As discussed in #12, this adds a link to the requirements section of Inside Playdate with C, so non-Mac devs know how to get the appropriate toolchain.

I also added commits that remove an outdated note about the SDK not being public, and added a note about Crank working on Linux.