### PR TITLE
Improve Linux experience for `crank run --device`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crankstart-cli"
-version = "0.2.6"
+version = "0.2.7"
 authors = ["Rob Tsuk <rob@tsuk.com>"]
 edition = "2018"
 description = "A command line tool for use with [Crankstart](https://github.com/pd-rs/crankstart)."

--- a/src/main.rs
+++ b/src/main.rs
@@ -504,6 +504,11 @@ impl Build {
             thread::sleep(duration);
         }
 
+        // Note: this sleep was determined by testing on one Linux system and may not be
+        // consistent; is there a better marker that we're ready to call pdutil run?
+        #[cfg(target_os = "linux")]
+        thread::sleep(duration * 10);
+
         let mut cmd = Command::new(&pdutil_path);
         cmd.arg(modem_path)
             .arg("run")

--- a/src/main.rs
+++ b/src/main.rs
@@ -500,6 +500,9 @@ impl Build {
             let _ = cmd.status()?;
         }
 
+        #[cfg(target_os = "linux")]
+        println!("Please press 'A' on the Playdate to exit Data Disk mode.");
+
         while !modem_path.exists() {
             thread::sleep(duration);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -467,6 +467,9 @@ impl Build {
             }
         }
 
+        #[cfg(target_os = "linux")]
+        println!("If your OS does not automatically mount your Playdate, please do so now.");
+
         while !data_path.exists() {
             thread::sleep(duration);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -459,6 +459,9 @@ impl Build {
             info!("datadisk cmd: {:#?}", cmd);
             let _ = cmd.status()?;
 
+            // Note: this device doesn't disappear on one Linux developer's system; is this always
+            // true?  Should we instead have a maximum delay and then continue regardless?
+            #[cfg(not(target_os = "linux"))]
             while modem_path.exists() {
                 thread::sleep(duration);
             }


### PR DESCRIPTION
This addresses some of the comments in #12.

* On Linux, don't wait for `modem_path` to disappear after initiating data disk mode, since (at least for me) it remains available.
* On Linux, sleep before issuing `pdutil run`.  Without a wait it was failing.  I based this on the Windows case, but on my machine it required 1s instead of 500ms.
* Print a message about pressing 'A' to exit Data Disk mode, after ejecting the Playdate, because I don't think the message on the Playdate screen is very clear about it, and crank is just waiting for the user.
* Print a message about mounting the Playdate, in case the OS doesn't do so automatically.

For the last two items, I chose a `println` rather than a log message because logging isn't enabled in crank by default - I didn't want to change the logging strategy and thought these would be helpful for newer users/developers.

I confirmed that the simulator case still worked as expected, with no changes, and that the changes worked as described with `--device`.

```
    Finished release [optimized] target(s) in 1.80s
If your OS does not automatically mount your Playdate, please do so now.
eject: cannot open /dev/sda: Permission denied
Please press 'A' on the Playdate to exit Data Disk mode.
```
(The eject error is a separate issue mentioned in #12.)

These changes are in the `cfg(unix)` path, and so also affect Mac, but I don't have a Mac setup to test with - hoping for confirmation there.