### PR TITLE
Removed need for `-Z build-std`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ The Playdate SDK installed in `$HOME/Developer/PlaydateSDK`.
 
 Rust, easiest installed via [rustup](https://rustup.rs)
 
-Rust toolchains __nightly__ needed for [build-std][] feature, installed with `rustup install nightly && rustup component add rust-src --toolchain nightly`, if you want to build for the Playdate device rather than the simulator.
+Rust toolchain __nightly__ needed for the unstable `aloc` feature, installed with `rustup install nightly`.
 
-[build-std]: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#build-std
+If you want want to build for the Playdate device, you will need the `thumbv7em-none-eabihf` target. Added with `rustup target add thumbv7em-none-eabihf`
 
 All of the requirements listed in [Inside Playdate with C](https://sdk.play.date/inside-playdate-with-c#_prerequisites).
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -601,7 +601,7 @@ impl Build {
         let current_dir = std::env::current_dir()?;
         let manifest_path_str;
         let mut args = if self.device {
-            vec!["+nightly", "build", "-Z", "build-std"]
+            vec!["+nightly", "build"]
         } else {
             vec!["build"]
         };


### PR DESCRIPTION
Fixes the error discussed at pd-rs/crankstart#30 by removing the need to build std from source. That does appear to be a bug caused from a regression in rust nightly, but this may still be a better option to lower the reliance on nightly rust.

Nightly is still necessary for the `aloc` feature, update readme to accomodate.