### PR TITLE
On Linux, find the Playdate serial device if possible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,6 +145,7 @@ dependencies = [
  "serde_derive",
  "structopt",
  "toml",
+ "walkdir",
  "zip",
  "zip-extensions",
 ]
@@ -390,6 +391,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "semver"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -561,6 +571,17 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,6 @@ structopt = "0.3.14"
 toml = "0.5.6"
 zip = "0.5"
 zip-extensions = "0.6"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+walkdir = "2.3.2"


### PR DESCRIPTION
```
This will use the /dev/serial/by-id/usb-Panic_Inc_Playdate_PDU1-*
symlink to find the appropriate serial device, if possible.  If the
PLAYDATE_SERIAL_DEVICE variable is set, that will take precedence.  If
multiple Playdate devices are found, the user is told, and the first is
used.  If none are found, the same /dev/ttyACM0 backup will be used.
```

This should eliminate the issue of a new crank user on Linux having to set `PLAYDATE_SERIAL_DEVICE` and having a bit of trouble getting started.  Other devices can use `/dev/ttyACM0`, like my keyboard, so I ran into this.

Should address the Linux case for #24.

I tested the following cases on Linux:
* No `--run` - the simulator ran the game OK.
* With `--run`, it found the correct (non-default) device and ran the game OK.
* If I force the code to fail the sanity check, it gives the expected warning and fails as expected.
* With my Playdate unplugged, it does as it would before this change: uses the default path and fails as expected.
* With a manual symlink inserted _before_ the real one, it prints that we're using it, fails the sanity check, then continues with the default path and fails as expected.
* With a manual symlink inserted _after_ the real one, it prints that we're using it, passes the sanity check, then continues and runs the game OK.