### PR TITLE
get the sdk path to find the executable on linux

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -579,7 +579,7 @@ impl Build {
 
         #[cfg(all(unix, not(target_os = "macos")))]
         let status = {
-            let mut cmd = Command::new("PlaydateSimulator");
+            let mut cmd = Command::new(playdate_sdk_path()?.join("bin").join("PlaydateSimulator"));
             cmd.arg(&pdx_path);
             cmd.status()?
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -580,7 +580,6 @@ impl Build {
         #[cfg(all(unix, not(target_os = "macos")))]
         let status = {
             let mut cmd = Command::new("PlaydateSimulator");
-
             cmd.arg(&pdx_path);
             cmd.status().or_else(|_| -> Result<ExitStatus, Error> {
                 info!("falling back on SDK path");


### PR DESCRIPTION
The method for running the PlaydateSimulator on Linux assumes that it's in your PATH. The desktop file that gets set up from the setup.sh script in the linux Playdate SDK just executes it from the SDK path, so I figure it's probably safe to do it the same way