### PR TITLE
Fix "file not found" error when the crate name contains hyphens

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -676,6 +676,7 @@ impl Build {
             .and_then(|target| target.metadata.as_ref())
             .and_then(|metadata| metadata.name.clone())
             .unwrap_or(to_title_case(&target_name));
+        let package_name = target_name.replace('-', "_");
         let source_path = self.make_source_dir(&overall_target_dir, &game_title)?;
         let dest_path = overall_target_dir.join(format!("{}.pdx", &game_title));
         if dest_path.exists() {
@@ -685,10 +686,10 @@ impl Build {
         let dir_name = if self.release { "release" } else { "debug" };
         if self.device {
             target_dir = target_dir.join("thumbv7em-none-eabihf").join(dir_name);
-            let lib_file = target_dir.join(format!("{}lib{}.a", target_path, target_name));
+            let lib_file = target_dir.join(format!("{}lib{}.a", target_path, package_name));
             self.compile_setup(&target_dir)?;
-            self.link_binary(&target_dir, &target_name, &lib_file)?;
-            self.make_binary(&target_dir, &target_name, &source_path)?;
+            self.link_binary(&target_dir, &package_name, &lib_file)?;
+            self.make_binary(&target_dir, &package_name, &source_path)?;
             self.copy_assets(&target_name, &project_path, &crank_manifest, &source_path)?;
             self.make_manifest(&crank_manifest, &target_name, &source_path)?;
             self.run_pdc(&source_path, &dest_path)?;
@@ -697,7 +698,7 @@ impl Build {
             }
         } else {
             target_dir = target_dir.join(dir_name).join(target_path);
-            self.link_dylib(&target_dir, &target_name, &source_path)?;
+            self.link_dylib(&target_dir, &package_name, &source_path)?;
             self.copy_assets(&target_name, &project_path, &crank_manifest, &source_path)?;
             self.make_manifest(&crank_manifest, &target_name, &source_path)?;
             self.run_pdc(&source_path, &dest_path)?;


### PR DESCRIPTION
The library is written with hyphens replaced with underscores.

----

Example that demonstrates the bug:

`Cargo.toml`:

```toml
[package]
name = "hello-world"
```

`Crank.toml`:

```toml
[[target]]
name = "hello-world"

[target.metadata]
name = "Hello World"
version = "0.1.0"
```

```
$ RUST_LOG=debug crank build --release --example hello-world

# ... snip ...

 DEBUG crank > copy: "C:\\Users\\jay\\other-projects\\crankstart\\target\\release\\examples/hello-world.dll" -> "C:\\Users\\jay\\other-projects\\crankstart\\target\\Hello World\\pdex.dll"
Error: The system cannot find the file specified. (os error 2)
```

```
$ ls -la target/release/examples/*.dll

-rwxr-xr-x 2 jay 197121 139264 Aug 26 17:58 target/release/examples/hello_world.dll*
-rwxr-xr-x 2 jay 197121 139264 Aug 26 17:58 target/release/examples/hello_world-30373b030c92bf1c.dll*
```

----

After applying the patch:

```
$ RUST_LOG=debug crank build --release --example hello-world

# ... snip ...

 DEBUG crank > copy: "C:\\Users\\jay\\other-projects\\crankstart\\target\\release\\examples/hello_world.dll" -> "C:\\Users\\jay\\other-projects\\crankstart\\target\\Hello World\\pdex.dll"
 INFO  crank > copy_assets
 
# ... etc, and it completes successfully!
```