### PR TITLE
Fix ARM compiler path on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This software is not sponsored or supported by Panic.
  * Switch to the nightly toolchain using `rustup toolchain install nightly`, required for the `build-std` feature.
  * If you want to build for the Playdate device, you will need the `thumbv7em-none-eabihf` target. Added with `rustup +nightly target add thumbv7em-none-eabihf`
  * All the requirements listed in [Inside Playdate with C](https://sdk.play.date/inside-playdate-with-c#_prerequisites).
+     * The GCC ARM compiler must be available in your system `PATH` environment variable. (This is usually done for you by the installer).
 
 ## Installation
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,8 +28,7 @@ const GCC_PATH_STR: &'static str = "/usr/local/bin/arm-none-eabi-gcc";
 #[cfg(all(unix, not(target_os = "macos")))]
 const GCC_PATH_STR: &'static str = "arm-none-eabi-gcc";
 #[cfg(windows)]
-const GCC_PATH_STR: &'static str =
-    r"C:\Program Files (x86)\Arm GNU Toolchain arm-none-eabi\12.3 rel1\bin\arm-none-eabi-gcc.exe";
+const GCC_PATH_STR: &'static str = "arm-none-eabi-gcc.exe";
 
 #[cfg(unix)]
 #[allow(unused)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ const GCC_PATH_STR: &'static str = "/usr/local/bin/arm-none-eabi-gcc";
 const GCC_PATH_STR: &'static str = "arm-none-eabi-gcc";
 #[cfg(windows)]
 const GCC_PATH_STR: &'static str =
-    r"C:\Program Files (x86)\GNU Tools Arm Embedded\9 2019-q4-major\bin\arm-none-eabi-gcc.exe";
+    r"C:\Program Files (x86)\Arm GNU Toolchain arm-none-eabi\12.3 rel1\bin\arm-none-eabi-gcc.exe";
 
 #[cfg(unix)]
 #[allow(unused)]


### PR DESCRIPTION
Looks like the compiler path changed in recent versions. I'm using Version `12.3.Rel1`, released July 28, 2023.

https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads

Possible fix for #44?