### PR TITLE
Fix linker error: undefined symbol `core::panicking::panic`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -651,6 +651,7 @@ impl Build {
             args.push("thumbv7em-none-eabihf");
 
             args.push("-Zbuild-std=core,alloc");
+            args.push("-Zbuild-std-features=panic_immediate_abort");
         }
 
         let envs = if self.device {
@@ -661,6 +662,7 @@ impl Build {
                     "-Ctarget-cpu=cortex-m7",
                     "-Clink-args=--emit-relocs",
                     "-Crelocation-model=pic",
+                    "-Cpanic=abort",
                 ]
                 .join(" "),
             );


### PR DESCRIPTION
Builds with `-Z build-std-features=panic_immediate_abort` to ensure the `core::panicking` plumbing is stripped.

See: https://github.com/rust-lang/rust/pull/55011

Adds `-Cpanic=abort` to RUSTFLAGS so that build profiles do not need to specify `panic = "abort"` in Cargo.toml. This can potentially allow simulator builds to customize panics. (Maybe printing to the console and stopping the event loop, for instance. But this work is TBD.)

Fixes https://github.com/pd-rs/crankstart/discussions/66