### PR TITLE
Fix simulator builds by adding +nightly

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -611,7 +611,7 @@ impl Build {
         let mut args = if self.device {
             vec!["+nightly", "build"]
         } else {
-            vec!["build"]
+            vec!["+nightly", "build"]
         };
 
         let project_path = if let Some(manifest_path) = opt.manifest_path.as_ref() {


### PR DESCRIPTION
Adding +nightly to simulator builds  seems to fix [pd-rs/crank/issues/57 ](https://github.com/pd-rs/crank/issues/57 )