### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This software is not sponsored or supported by Panic.
 
 ## Requirements
 
- * The Playdate SDK installed in `$HOME/Developer/PlaydateSDK` on Linux or MacOS, `$HOME/Documents/PlaydateSDK` on Window, or at the path specified by the `$PLAYDATE_SDK` environment variable.
+ * The Playdate SDK installed in `$HOME/Developer/PlaydateSDK` on Linux or MacOS, `$HOME/Documents/PlaydateSDK` on Window, or at the path specified by the `$PLAYDATE_SDK_PATH` environment variable.
  * Rust, easiest installed via [rustup](https://rustup.rs).
  * Switch to the nightly toolchain using `rustup toolchain install nightly`, required for the `build-std` feature.
  * If you want to build for the Playdate device, you will need the `thumbv7em-none-eabihf` target. Added with `rustup +nightly target add thumbv7em-none-eabihf`

--- a/src/main.rs
+++ b/src/main.rs
@@ -378,7 +378,8 @@ impl Build {
         let status = cmd
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
-            .status()?;
+            .status()
+            .with_context(|| format!("Command failed: {cmd:?}"))?;
         if !status.success() {
             bail!("pdc failed with error {:?}", status);
         }


### PR DESCRIPTION
The README mentions a `PLAYDATE_SDK` environment variable where it should read `PLAYDATE_SDK_PATH`. This tripped me up when I tried to set up crank and crankstart and I found the original error message cryptic:
```
$ crank run --release --example hello_world
    Finished `release` profile [optimized] target(s) in 0.04s
Error: No such file or directory (os error 2)
```
With this change, it now shows:
```
$ crank run --release --example hello_world
    Finished `release` profile [optimized] target(s) in 0.01s
Error: Command failed: "/home/jack/Developer/PlaydateSDK/bin/pdc" "--strip" "/home/jack/repos/crankstart/target/Hello World" "/home/jack/repos/crankstart/target/Hello World.pdx"

Caused by:
    No such file or directory (os error 2)
```
which is a little more legible.