### PR TITLE
Make rust emitted code compatible with Rev A Playdate hardware

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -660,6 +660,7 @@ impl Build {
                 "RUSTFLAGS",
                 [
                     "-Ctarget-cpu=cortex-m7",
+                    "-Ctarget-feature=-fp64", // Rev A hardware seems to not have 64-bit floating point support
                     "-Clink-args=--emit-relocs",
                     "-Crelocation-model=pic",
                     "-Cpanic=abort",


### PR DESCRIPTION
Hi there! I've been working on a Playdate game in rust for the last 9 months using crankstart. Thanks for all the work on this project which has made that possible! I have a bunch of changes to both [crankstart](https://github.com/jder/crankstart) and [crank](https://github.com/jder/crank), some of which are probably useful to others, so I'm planning to start sending some back upstream. Here's the first! Changelog below:

--

The FPU settings for C code are `-mfpu=fpv5-sp-d16`, the `-sp-` part means that double precision floating point is unsupported. The [rust docs](https://doc.rust-lang.org/nightly/rustc/platform-support/thumbv7em-none-eabi.html#table-of-supported-cpus-for-thumbv7em-none-eabihf) show that getting this same effect from rustc-emitted code requires this additional target feature. Note that at the moment this produces a warning that this target flag is unstable. 

Without this, I was getting "undefined instruction" errors for f64 instructions on the original Playdate hardware, with this change it seems to be resolved.